### PR TITLE
Add NOT IN predicate and CastAsAny helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Predicado `NotIn` para colunas, aceitando listas de valores ou subconsultas.
 - Helper `CastAsAny` para facilitar o uso de slices tipados em chamadas variádicas (`In`/`NotIn`) e exemplo correspondente em `examples/`.
+- Método `WhereOr` para combinar blocos de predicados com `OR` mantendo o agrupamento do `WHERE`.
 
 ### Changed
 - Nothing yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Added
-- Nothing yet.
+- Predicado `NotIn` para colunas, aceitando listas de valores ou subconsultas.
+- Helper `CastAsAny` para facilitar o uso de slices tipados em chamadas variádicas (`In`/`NotIn`) e exemplo correspondente em `examples/`.
 
 ### Changed
 - Nothing yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Predicado `NotIn` para colunas, aceitando listas de valores ou subconsultas.
 - Helper `CastAsAny` para facilitar o uso de slices tipados em chamadas variádicas (`In`/`NotIn`) e exemplo correspondente em `examples/`.
-- Método `WhereOr` para combinar blocos de predicados com `OR` mantendo o agrupamento do `WHERE`.
 
 ### Changed
 - Nothing yet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,20 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Added
+- Nothing yet.
+
+### Changed
+- Nothing yet.
+
+### Fixed
+- Nothing yet.
+
+## [v0.8.0] - 2025-11-25
+
+### Added
 - Predicado `NotIn` para colunas, aceitando listas de valores ou subconsultas.
 - Helper `CastAsAny` para facilitar o uso de slices tipados em chamadas variádicas (`In`/`NotIn`) e exemplo correspondente em `examples/`.
+- Documentação de composição de `WHERE` usando `Or` para evitar aninhamentos desnecessários.
 
 ### Changed
 - Nothing yet.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,24 @@ q := chizuql.New().
 sql, args := q.Build()
 ```
 
+### Filtro com NOT IN + CastAsAny
+```go
+logIDs := []int{10, 11, 12}
+
+q := chizuql.New().
+    Select("v.vag_id").
+    From(chizuql.TableAlias("vag", "v")).
+    Where(
+        chizuql.Col("v.vag_id").NotIn(chizuql.CastAsAny(logIDs)...),
+        chizuql.Col("v.vag_id").Gt(100),
+    )
+
+sql, args := q.Build()
+```
+
+- `CastAsAny` converte slices tipados para `[]any`, facilitando chamadas variádicas.
+- `NotIn` aceita tanto listas de valores quanto subconsultas, reutilizando o comportamento de placeholders do `In`.
+
 ### Locks de linha com `FOR UPDATE`/`LOCK IN SHARE MODE`
 ```go
 lockShared := chizuql.New().

--- a/README.md
+++ b/README.md
@@ -199,23 +199,29 @@ q := chizuql.New().
 sql, args := q.Build()
 ```
 
-### Filtro com NOT IN + CastAsAny
+### Filtro com NOT IN + CastAsAny (com OR)
 ```go
-logIDs := []int{10, 11, 12}
+skipIDs := []int64{12, 15}
 
 q := chizuql.New().
-    Select("v.vag_id").
-    From(chizuql.TableAlias("vag", "v")).
+    Select("doc_id", "doc_date").
+    From("doc_update_queue").
     Where(
-        chizuql.Col("v.vag_id").NotIn(chizuql.CastAsAny(logIDs)...),
-        chizuql.Col("v.vag_id").Gt(100),
-    )
+        chizuql.Col("doc_date").Gt("2025-01-01"),
+        chizuql.Col("doc_id").NotIn(chizuql.CastAsAny(skipIDs)...),
+    ).
+    WhereOr(
+        chizuql.Col("doc_id").In(101, 102),
+        chizuql.Col("priority").Gt(10),
+    ).
+    OrderBy("doc_id ASC")
 
 sql, args := q.Build()
 ```
 
 - `CastAsAny` converte slices tipados para `[]any`, facilitando chamadas variádicas.
 - `NotIn` aceita tanto listas de valores quanto subconsultas, reutilizando o comportamento de placeholders do `In`.
+- `WhereOr` adiciona blocos de predicados com `OR` sem perder o agrupamento aplicado pela cláusula `Where`.
 
 ### Locks de linha com `FOR UPDATE`/`LOCK IN SHARE MODE`
 ```go

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ q := chizuql.New().
 sql, args := q.Build()
 ```
 
-### Filtro com NOT IN + CastAsAny (com OR)
+### Filtro com NOT IN + CastAsAny (usando Or)
 ```go
 skipIDs := []int64{12, 15}
 
@@ -207,12 +207,14 @@ q := chizuql.New().
     Select("doc_id", "doc_date").
     From("doc_update_queue").
     Where(
-        chizuql.Col("doc_date").Gt("2025-01-01"),
-        chizuql.Col("doc_id").NotIn(chizuql.CastAsAny(skipIDs)...),
-    ).
-    WhereOr(
-        chizuql.Col("doc_id").In(101, 102),
-        chizuql.Col("priority").Gt(10),
+        chizuql.Or(
+            chizuql.And(
+                chizuql.Col("doc_date").Gt("2025-01-01"),
+                chizuql.Col("doc_id").NotIn(chizuql.CastAsAny(skipIDs)...),
+            ),
+            chizuql.Col("doc_id").In(101, 102),
+            chizuql.Col("priority").Gt(10),
+        ),
     ).
     OrderBy("doc_id ASC")
 
@@ -221,7 +223,7 @@ sql, args := q.Build()
 
 - `CastAsAny` converte slices tipados para `[]any`, facilitando chamadas variádicas.
 - `NotIn` aceita tanto listas de valores quanto subconsultas, reutilizando o comportamento de placeholders do `In`.
-- `WhereOr` adiciona blocos de predicados com `OR` sem perder o agrupamento aplicado pela cláusula `Where`.
+- `Or` permite combinar blocos completos de predicados dentro do `Where`, preservando o agrupamento desejado.
 
 ### Locks de linha com `FOR UPDATE`/`LOCK IN SHARE MODE`
 ```go

--- a/builder.go
+++ b/builder.go
@@ -1478,6 +1478,20 @@ func toValueExpressions(values ...any) []Expression {
 	return out
 }
 
+// CastAsAny converts a typed slice into a []any to simplify usage with variadic helpers.
+func CastAsAny[T any](values []T) []any {
+	if values == nil {
+		return nil
+	}
+
+	out := make([]any, len(values))
+	for i, v := range values {
+		out[i] = v
+	}
+
+	return out
+}
+
 func toSQLExpression(value any) Expression {
 	switch v := value.(type) {
 	case string:

--- a/builder.go
+++ b/builder.go
@@ -537,41 +537,45 @@ func (q *Query) join(kind string, table any, on ...Predicate) *Query {
 
 // Where appends predicates to the WHERE clause combined with AND.
 func (q *Query) Where(predicates ...Predicate) *Query {
-	q.appendWhere("AND", predicates...)
-
-	return q
-}
-
-// WhereOr appends predicates to the WHERE clause combined with OR.
-func (q *Query) WhereOr(predicates ...Predicate) *Query {
-	q.appendWhere("OR", predicates...)
-
-	return q
-}
-
-func (q *Query) appendWhere(op string, predicates ...Predicate) {
 	if len(predicates) == 0 {
-		return
+		return q
 	}
 
-	group := combinePredicates(op, predicates...)
+	if len(predicates) == 1 {
+		if cp, ok := predicates[0].(compoundPredicate); ok {
+			if q.where == nil {
+				q.where = cp
+
+				return q
+			}
+
+			q.where = And(q.where, cp)
+
+			return q
+		}
+
+		group := And(predicates...)
+
+		if q.where == nil {
+			q.where = group
+
+			return q
+		}
+
+		q.where = And(q.where, group)
+
+		return q
+	}
+
 	if q.where == nil {
-		q.where = group
+		q.where = And(predicates...)
 
-		return
+		return q
 	}
 
-	if strings.ToUpper(op) == "OR" {
-		combined := make([]Predicate, 0, len(predicates)+1)
-		combined = append(combined, q.where)
-		combined = append(combined, predicates...)
+	q.where = And(q.where, And(predicates...))
 
-		q.where = Or(combined...)
-
-		return
-	}
-
-	q.where = And(q.where, group)
+	return q
 }
 
 // Having appends predicates to the HAVING clause combined with AND.
@@ -1530,13 +1534,4 @@ func toSQLExpressions(values ...any) []Expression {
 	}
 
 	return out
-}
-
-func combinePredicates(op string, predicates ...Predicate) Predicate {
-	switch strings.ToUpper(op) {
-	case "OR":
-		return Or(predicates...)
-	default:
-		return And(predicates...)
-	}
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -901,6 +901,35 @@ func TestEmptyInListPanics(t *testing.T) {
 	}, "IN list cannot be empty")
 }
 
+func TestNotInWithValues(t *testing.T) {
+	ids := []int{1, 2, 3}
+
+	q := New().
+		Select("id").
+		From("users").
+		Where(Col("id").NotIn(CastAsAny(ids)...))
+
+	assertBuild(t, q,
+		"SELECT id FROM users WHERE (id NOT IN (?, ?, ?))",
+		[]any{1, 2, 3},
+	)
+}
+
+func TestNotInWithSubquery(t *testing.T) {
+	q := New().
+		Select("id").
+		From("users").
+		Where(
+			Col("id").NotIn(New().Select("user_id").From("logs")),
+			Col("status").Eq("active"),
+		)
+
+	assertBuild(t, q,
+		"SELECT id FROM users WHERE (id NOT IN (SELECT user_id FROM logs) AND status = ?)",
+		[]any{"active"},
+	)
+}
+
 func assertPanicsWith(t *testing.T, fn func(), msg string) {
 	t.Helper()
 

--- a/examples/queries.md
+++ b/examples/queries.md
@@ -452,7 +452,7 @@ args: ["2024-01-01" "2024-02-01" "archived" "zzz"]
 - `Between` e `NotBetween` aceitam qualquer expressão, inclusive `Raw` ou subconsultas.
 - Vários predicados informados em `Where` continuam agrupados por `AND`.
 
-### 13.1 Filtro com NOT IN usando CastAsAny e OR
+### 13.1 Filtro com NOT IN usando CastAsAny e Or
 **Query**
 ```go
 skipIDs := []int64{12, 15}
@@ -461,12 +461,14 @@ q := chizuql.New().
     Select("doc_id", "doc_date").
     From("doc_update_queue").
     Where(
-        chizuql.Col("doc_date").Gt("2025-01-01"),
-        chizuql.Col("doc_id").NotIn(chizuql.CastAsAny(skipIDs)...),
-    ).
-    WhereOr(
-        chizuql.Col("doc_id").In(101, 102),
-        chizuql.Col("priority").Gt(10),
+        chizuql.Or(
+            chizuql.And(
+                chizuql.Col("doc_date").Gt("2025-01-01"),
+                chizuql.Col("doc_id").NotIn(chizuql.CastAsAny(skipIDs)...),
+            ),
+            chizuql.Col("doc_id").In(101, 102),
+            chizuql.Col("priority").Gt(10),
+        ),
     ).
     OrderBy("doc_id ASC")
 
@@ -481,7 +483,7 @@ args: ["2025-01-01" 12 15 101 102 10]
 
 **Comentários**
 - `CastAsAny` converte slices tipados em `[]any`, facilitando o uso em chamadas variádicas como `In`/`NotIn`.
-- `WhereOr` adiciona blocos extras com `OR` preservando o agrupamento do `Where` inicial.
+- `Or` permite adicionar blocos extras com `OR` preservando o agrupamento do `Where` inicial.
 
 ### 14. Agrupamentos avançados com GROUPING SETS e ROLLUP
 **Query**

--- a/examples/queries.md
+++ b/examples/queries.md
@@ -452,6 +452,32 @@ args: ["2024-01-01" "2024-02-01" "archived" "zzz"]
 - `Between` e `NotBetween` aceitam qualquer expressão, inclusive `Raw` ou subconsultas.
 - Vários predicados informados em `Where` continuam agrupados por `AND`.
 
+### 13.1 Filtro com NOT IN usando CastAsAny
+**Query**
+```go
+logIDs := []int{10, 11, 12}
+
+q := chizuql.New().
+    Select("v.vag_id").
+    From(chizuql.TableAlias("vag", "v")).
+    Where(
+        chizuql.Col("v.vag_id").NotIn(chizuql.CastAsAny(logIDs)...),
+        chizuql.Col("v.vag_id").Gt(100),
+    )
+
+sql, args := q.Build()
+```
+
+**Saída gerada**
+```
+SELECT v.vag_id FROM vag AS v WHERE (v.vag_id NOT IN (?, ?, ?) AND v.vag_id > ?)
+args: [10 11 12 100]
+```
+
+**Comentários**
+- `CastAsAny` converte slices tipados em `[]any`, facilitando o uso em chamadas variádicas como `In`/`NotIn`.
+- `NotIn` aceita tanto slices quanto subconsultas, mantendo o tratamento de placeholders por dialeto.
+
 ### 14. Agrupamentos avançados com GROUPING SETS e ROLLUP
 **Query**
 ```go


### PR DESCRIPTION
## Summary
- add a Column.NotIn predicate that handles value lists and subqueries while reusing the existing IN safeguards
- introduce a CastAsAny helper plus README/examples documentation and changelog entry for the new API
- cover the new predicate with tests and ensure examples align with the updated API

## Testing
- go test ./...
- golangci-lint run --fix ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd0f9faf48322bcd7ffb3799e026d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suporte a filtro NOT IN para colunas (aceita listas de valores ou subconsultas).
  * Helper CastAsAny para facilitar uso de slices tipados em chamadas variádicas (In/NotIn).
  * Melhor composição de predicados em WHERE ao combinar condições compostas e simples.

* **Documentation**
  * Nova seção com exemplo demonstrando NOT IN + CastAsAny combinado com lógica OR.

* **Tests**
  * Testes adicionados cobrindo NOT IN (valores e subqueries) e combinações OR/AND.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->